### PR TITLE
Add info about balance and last indications

### DIFF
--- a/pesc/client.py
+++ b/pesc/client.py
@@ -52,6 +52,13 @@ class PescMeter(PescObject):
                                      headers=headers)
         return response.json()
 
+    @property
+    def indication_info(self):
+        url = '/'.join((self.api_url, self.provider, 'indication-info', self.meter_id))
+        headers = {'content-type': 'application/json; charset=utf-8'}
+        response = self.session.get(url, headers=headers)
+        return response.json()
+
     def post_indication(self, day=0, night=0):
         url = '/'.join((self.api_url, self.provider, 'indication/new'))
         headers = {'content-type': 'application/json; charset=utf-8'}
@@ -149,6 +156,15 @@ class PescAccount(PescObject):
         response = self.session.post(url, data=json.dumps(data),
                                      headers=headers)
         return response.json()['address']
+
+    @property
+    def balance(self):
+        url = '/'.join((self.api_url, self.provider, 'balance'))
+        headers = {'content-type': 'application/json; charset=utf-8'}
+        data = {'accountNumber': self.account_id}
+        response = self.session.post(url, data=json.dumps(data),
+                                     headers=headers)
+        return response.json()
 
     def __repr__(self):
         return 'Account {} at {}'.format(self.account_id, self.address)


### PR DESCRIPTION
Add `indication_info` method for PescMeter to get last saved indications:
```python
{'demandNewIndication': False, 'lastIndication': {'type': 'Заявленные показания', 'scaleValues': [{'value': 693, 'scale': 'NIGHT'}, {'value': 1490, 'scale': 'DAY'}], 'date': '29-09-2018'}, 'numberOfDigits': 6, 'numberOfScales': 2, 'scales': ['DAY', 'NIGHT']}
```

Also added `balance` method to PescAccount to get current saldo, balance, etc.
```python
{'accountSaldo': -553.53, 'accountBalance': -553.53, 'accountFine': 0.0}
```