### PR TITLE
feat(api): wrap new API version, add new methods

### DIFF
--- a/pesc/client.py
+++ b/pesc/client.py
@@ -20,7 +20,7 @@ class PescObject:
 
     """
 
-    def __init__(self, session=requests.Session()):
+    def __init__(self, session):
         self.session = session
         self.session.headers.update(
             {
@@ -39,7 +39,7 @@ class PescMeter(PescObject):
         super().__init__(session=session)
         self.account_id = account_id
         self.provider_id = provider_id
-        self.api_url = ROOT_URL + "/api"
+        self.api_url = f"{ROOT_URL}/api"
         self.meter_id = meter_id
 
     @property
@@ -50,9 +50,15 @@ class PescMeter(PescObject):
 
     def get_indications(
         self,
-        date_from=datetime.now().strftime("01.01.%Y"),
-        date_to=datetime.now().strftime("%d.%m.%Y"),
+        date_from=None,
+        date_to=None,
     ):
+        if date_from is None:
+            date_from = datetime.now().strftime("01.01.%Y")
+        if date_to is None:
+            date_to = datetime.now().strftime("%d.%m.%Y")
+
+
         response = self.session.get(
             f"{self.api_url}/v7/reading/individuals",
             params={
@@ -77,7 +83,7 @@ class PescMeter(PescObject):
         return response.json()
 
     def __repr__(self):
-        return "Meter {} from account {}".format(self.meter_id, self.account_id)
+        return f"Meter {self.meter_id} from account {self.account_id}"
 
 
 class PescAccount(PescObject):
@@ -88,15 +94,20 @@ class PescAccount(PescObject):
 
     def __init__(self, session, account_id, provider_id):
         super().__init__(session=session)
-        self.api_url = ROOT_URL + "/api"
+        self.api_url = f"{ROOT_URL}/api"
         self.account_id = account_id
         self.provider_id = provider_id
 
     def get_bills(
         self,
-        date_from=datetime.now().strftime("01.01.%Y"),
-        date_to=datetime.now().strftime("%d.%m.%Y"),
+        date_from=None,
+        date_to=None,
     ):
+        if date_from is None:
+            date_from = datetime.now().strftime("01.01.%Y")
+        if date_to is None:
+            date_to = datetime.now().strftime("%d.%m.%Y")
+
         response = self.session.get(
             f"{self.api_url}/v7/bills/payments",
             params={
@@ -107,9 +118,10 @@ class PescAccount(PescObject):
             },
         )
 
+        bill_ids = response.json()
         return [
             self.session.get(f"{self.api_url}/v8/payments/bills/{bill_id}").json()
-            for bill_id in response.json()
+            for bill_id in bill_ids
         ]
 
     def download_bill(self, bill_id, filename):
@@ -124,9 +136,15 @@ class PescAccount(PescObject):
 
     def get_payments(
         self,
-        date_from=datetime.now().strftime("01.01.%Y"),
-        date_to=datetime.now().strftime("%d.%m.%Y"),
+        date_from=None,
+        date_to=None,
     ):
+        if date_from is None:
+            date_from = datetime.now().strftime("01.01.%Y")
+        if date_to is None:
+            date_to = datetime.now().strftime("%d.%m.%Y")
+
+
         response = self.session.get(
             f"{self.api_url}/v7/payments",
             params={
@@ -137,9 +155,10 @@ class PescAccount(PescObject):
             },
         )
 
+        payment_ids = response.json()
         return [
             self.session.get(f"{self.api_url}/v8/payments/{payment_id}").json()
-            for payment_id in response.json()
+            for payment_id in payment_ids
         ]
 
     def get_meters(self):
@@ -147,6 +166,7 @@ class PescAccount(PescObject):
             f"{self.api_url}/v6/accounts/{self.account_id}/meters/info"
         )
 
+        meters = response.json()
         return [
             PescMeter(
                 self.session,
@@ -154,7 +174,7 @@ class PescAccount(PescObject):
                 self.provider_id,
                 meter["id"]["registration"],
             )
-            for meter in response.json()
+            for meter in meters
         ]
 
     @property
@@ -174,7 +194,7 @@ class PescAccount(PescObject):
         ).json()
 
     def __repr__(self):
-        return "Account {} at {}".format(self.account_id, self.address)
+        return f"Account {self.account_id} at {self.address}"
 
 
 class PescClient(PescObject):
@@ -188,8 +208,8 @@ class PescClient(PescObject):
         PHONE = "PHONE"
 
     def __init__(self):
-        super().__init__()
-        self.api_url = ROOT_URL + "/api"
+        super().__init__(requests.Session())
+        self.api_url = f"{ROOT_URL}/api"
         self.login = None
         self.password = None
         self.type = None

--- a/pesc/client.py
+++ b/pesc/client.py
@@ -77,7 +77,7 @@ class PescMeter(PescObject):
         return response.json()
 
     def __repr__(self):
-        return "Meter {} from account {}".format(self.meter_number, self.account_id)
+        return "Meter {} from account {}".format(self.meter_id, self.account_id)
 
 
 class PescAccount(PescObject):

--- a/pesc/client.py
+++ b/pesc/client.py
@@ -258,13 +258,38 @@ class PescClient(PescObject):
         Returns
         _______
         dict
-            {'email': 'null@prg.re', 'emailConfirmed': True, 'phoneConfirmed': True,
-             'superUserMode': False, 'guideViewed': True, 'phoneExists': True,
-             'hasPersonalInfo': True} or
-            {'errors': [{'code': 5, 'message': 'Неавторизованный доступ'}]}
+        {
+            'userId': int,
+            'name': {
+                'first': str,
+                'last': str,
+                'patronymic': optional[str]
+            },
+            'fields': List[dict],
+            'phone': str,
+            'email': str,
+            'isConfirmed': bool,
+            'isOnBoardingViewed': bool
+        }
+        or
+        {
+            'errors': [
+                {'code': 401, 'message': 'Неавторизованный доступ'}
+            ]
+        }
         """
 
         response = self.session.get(self.api_url + "/v6/users/current")
+        if response.status_code != 200:
+            return {
+                "errors": [
+                    {
+                        "code": response.status_code,
+                        "message": response.json().get("message", "Unknown error"),
+                    }
+                ]
+            }
+
         return response.json()
 
     def get_accounts(self):

--- a/pesc/client.py
+++ b/pesc/client.py
@@ -5,6 +5,7 @@ pesc.client
 """
 
 import json
+import jwt
 import requests
 
 from datetime import datetime
@@ -156,9 +157,6 @@ class PescAccount(PescObject):
             for meter in response.json()
         ]
 
-    # get_address
-    # https://ikus.pesc.ru/api/v8/accounts/.../address
-
     @property
     def meters(self):
         return self.get_meters()
@@ -173,13 +171,9 @@ class PescAccount(PescObject):
 
     @property
     def debt(self):
-        # https://ikus.pesc.ru/api/v8/accounts/../payments/bills/current ?
-
-        url = "/".join((self.api_url, self.provider, "debt"))
-        headers = {"content-type": "application/json; charset=utf-8"}
-        data = {"accountNumber": self.account_id, "serviceType": self.service_type}
-        response = self.session.post(url, data=json.dumps(data), headers=headers)
-        return response.json()
+        return self.session.get(
+            f"{self.api_url}/v8/accounts/{self.account_id}/payments/bills/current"
+        ).json()
 
     @property
     def active_payments(self):
@@ -191,13 +185,9 @@ class PescAccount(PescObject):
 
     @property
     def address(self):
-        # https://ikus.pesc.ru/api/v8/accounts/.../address ?
-
-        url = "/".join((self.api_url, self.provider, "address"))
-        headers = {"content-type": "application/json; charset=utf-8"}
-        data = {"accountNumber": self.account_id, "serviceType": self.service_type}
-        response = self.session.post(url, data=json.dumps(data), headers=headers)
-        return response.json()["address"]
+        return self.session.get(
+            f"{self.api_url}/v8/accounts/{self.account_id}/address"
+        ).json()
 
     def __repr__(self):
         return "Account {} at {}".format(self.account_id, self.address)
@@ -363,6 +353,17 @@ class PescClient(PescObject):
         dict
             {'logoutSuccess': True}
         """
-        url = self.api_url + "/logout"
-        response = self.session.get(url)
-        return response.json()
+
+        token_id = json.loads(
+            jwt.decode(
+                self.session.headers.get("Authorization").split(" ")[1],
+                options={"verify_signature": False},
+            )["sub"]
+        )["tokenId"]
+
+        return {
+            "logoutSuccess": self.session.delete(
+                f"{self.api_url}/v1/auth/session/{token_id}"
+            ).status_code
+            == 200
+        }

--- a/pesc/client.py
+++ b/pesc/client.py
@@ -34,48 +34,45 @@ class PescMeter(PescObject):
 
     """
 
-    def __init__(
-        self, session, account_id, provider, service_type, meter_id, meter_number
-    ):
+    def __init__(self, session, account_id, provider_id, meter_id):
         super().__init__(session=session)
         self.account_id = account_id
-        self.provider = provider
-        self.service_type = service_type
-        self.api_url = ROOT_URL + "/application/accounts"
+        self.provider_id = provider_id
+        self.api_url = ROOT_URL + "/api"
         self.meter_id = meter_id
-        self.meter_number = meter_number
 
     @property
     def info(self):
-        url = "/".join((self.api_url, self.provider, "meters", str(self.meter_id)))
-        headers = {"content-type": "application/json; charset=utf-8"}
-        response = self.session.get(url, headers=headers)
-        return response.json()
+        return self.session.get(
+            f"{self.api_url}/v6/accounts/{self.account_id}/meters/info"
+        ).json()
 
     def get_indications(
         self,
-        date_from=datetime.now().strftime("01-01-%Y"),
-        date_to=datetime.now().strftime("%d-%m-%Y"),
+        date_from=datetime.now().strftime("01.01.%Y"),
+        date_to=datetime.now().strftime("%d.%m.%Y"),
     ):
-        url = "/".join((self.api_url, self.provider, "indications"))
-        headers = {"content-type": "application/json; charset=utf-8"}
-        data = {"meterId": self.meter_id, "dateFrom": date_from, "dateTo": date_to}
-        response = self.session.post(url, data=json.dumps(data), headers=headers)
+        response = self.session.get(
+            f"{self.api_url}/v7/reading/individuals",
+            params={
+                "provider": self.provider_id,
+                "account": self.account_id,
+                "from": date_from,
+                "to": date_to,
+            },
+        )
+
         return response.json()
 
     def post_indication(self, day=0, night=0):
-        url = "/".join((self.api_url, self.provider, "indication/new"))
-        headers = {"content-type": "application/json; charset=utf-8"}
-        data = {
-            "account": {"accountNumber": self.account_id},
-            "serviceType": self.service_type,
-            "meterId": self.meter_id,
-            "indication": [
-                {"scale": "DAY", "value": day},
-                {"scale": "NIGHT", "value": night},
+        response = self.session.post(
+            f"{self.api_url}/v8/accounts/{self.account_id}/meters/{self.meter_id}/reading",
+            json=[
+                {"scaleId": 2, "value": day},
+                {"scaleId": 3, "value": night},
             ],
-        }
-        response = self.session.post(url, data=json.dumps(data), headers=headers)
+        )
+
         return response.json()
 
     def __repr__(self):
@@ -88,12 +85,11 @@ class PescAccount(PescObject):
 
     """
 
-    def __init__(self, session, account_id, provider_name, service_type):
+    def __init__(self, session, account_id, provider_id):
         super().__init__(session=session)
         self.api_url = ROOT_URL + "/api"
         self.account_id = account_id
-        self.provider = provider_name
-        self.service_type = service_type
+        self.provider_id = provider_id
 
     def get_bills(
         self,
@@ -101,9 +97,9 @@ class PescAccount(PescObject):
         date_to=datetime.now().strftime("%d.%m.%Y"),
     ):
         response = self.session.get(
-            self.api_url + "/v7/bills/payments",
+            f"{self.api_url}/v7/bills/payments",
             params={
-                "provider": self.provider,
+                "provider": self.provider_id,
                 "account": self.account_id,
                 "from": date_from,
                 "to": date_to,
@@ -111,14 +107,16 @@ class PescAccount(PescObject):
         )
 
         return [
-            self.session.get(self.api_url + "/v8/payments/bills/" + bill_id).json()
+            self.session.get(f"{self.api_url}/v8/payments/bills/{bill_id}").json()
             for bill_id in response.json()
         ]
-    
-    def download_bill(self, bill_id, filename):
-        uuid = self.session.get(self.api_url + f"{self.account_id}/payments/bills/{bill_id}/uuid").json()
 
-        response = self.session.get(self.api_url + f"/v1/file/{uuid}", stream=True)
+    def download_bill(self, bill_id, filename):
+        uuid = self.session.get(
+            f"{self.api_url}/v7/accounts/{self.account_id}/payments/bills/{bill_id}/uuid"
+        ).text
+
+        response = self.session.get(f"{self.api_url}/v1/file/{uuid}", stream=True)
         with open(filename, "wb") as file:
             for chunk in response.iter_content(chunk_size=8192):
                 file.write(chunk)
@@ -129,9 +127,9 @@ class PescAccount(PescObject):
         date_to=datetime.now().strftime("%d.%m.%Y"),
     ):
         response = self.session.get(
-            self.api_url + "/v7/payments",
+            f"{self.api_url}/v7/payments",
             params={
-                "provider": self.provider,
+                "provider": self.provider_id,
                 "account": self.account_id,
                 "from": date_from,
                 "to": date_to,
@@ -139,23 +137,21 @@ class PescAccount(PescObject):
         )
 
         return [
-            self.session.get(self.api_url + "/v8/payments/" + payment_id).json()
+            self.session.get(f"{self.api_url}/v8/payments/{payment_id}").json()
             for payment_id in response.json()
         ]
 
     def get_meters(self):
-        url = "/".join((self.api_url, self.provider, "meters"))
-        headers = {"content-type": "application/json; charset=utf-8"}
-        data = {"accountNumber": self.account_id, "serviceType": self.service_type}
-        response = self.session.post(url, data=json.dumps(data), headers=headers)
+        response = self.session.get(
+            f"{self.api_url}/v6/accounts/{self.account_id}/meters/info"
+        )
+
         return [
             PescMeter(
                 self.session,
                 self.account_id,
-                self.provider,
-                self.service_type,
-                meter["meterId"],
-                meter["meterNumber"],
+                self.provider_id,
+                meter["id"]["registration"],
             )
             for meter in response.json()
         ]
@@ -177,6 +173,8 @@ class PescAccount(PescObject):
 
     @property
     def debt(self):
+        # https://ikus.pesc.ru/api/v8/accounts/../payments/bills/current ?
+
         url = "/".join((self.api_url, self.provider, "debt"))
         headers = {"content-type": "application/json; charset=utf-8"}
         data = {"accountNumber": self.account_id, "serviceType": self.service_type}
@@ -193,6 +191,8 @@ class PescAccount(PescObject):
 
     @property
     def address(self):
+        # https://ikus.pesc.ru/api/v8/accounts/.../address ?
+
         url = "/".join((self.api_url, self.provider, "address"))
         headers = {"content-type": "application/json; charset=utf-8"}
         data = {"accountNumber": self.account_id, "serviceType": self.service_type}
@@ -213,7 +213,7 @@ class PescClient(PescObject):
         EMAIL = "EMAIL"
         PHONE = "PHONE"
 
-    def __init__(self, session_path=None):
+    def __init__(self):
         super().__init__()
         self.api_url = ROOT_URL + "/api"
         self.login = None
@@ -244,7 +244,7 @@ class PescClient(PescObject):
         self.type = type
 
         response = self.session.post(
-            self.api_url + "/v8/users/auth",
+            f"{self.api_url}/v8/users/auth",
             json={
                 "login": login,
                 "password": password,
@@ -299,7 +299,7 @@ class PescClient(PescObject):
             }
         """
 
-        response = self.session.get(self.api_url + "/v6/users/current")
+        response = self.session.get(f"{self.api_url}/v6/users/current")
         if response.status_code != 200:
             return {
                 "errors": [
@@ -320,7 +320,7 @@ class PescClient(PescObject):
         _______
         List[PescAccount]
         """
-        response = self.session.get(self.api_url + "/v8/accounts")
+        response = self.session.get(f"{self.api_url}/v8/accounts")
         if response.status_code != 200:
             return {
                 "errors": [
@@ -336,7 +336,6 @@ class PescClient(PescObject):
                 self.session,
                 account["id"],
                 account["service"]["providerId"],
-                account["service"]["id"],
             )
             for account in response.json()
         ]

--- a/pesc/client.py
+++ b/pesc/client.py
@@ -21,6 +21,11 @@ class PescObject:
 
     def __init__(self, session=requests.Session()):
         self.session = session
+        self.session.headers.update(
+            {
+                "Content-Type": "application/json; charset=utf-8",
+            }
+        )
 
 
 class PescMeter(PescObject):
@@ -85,41 +90,58 @@ class PescAccount(PescObject):
 
     def __init__(self, session, account_id, provider_name, service_type):
         super().__init__(session=session)
-        self.api_url = ROOT_URL + "/application/accounts"
+        self.api_url = ROOT_URL + "/api"
         self.account_id = account_id
         self.provider = provider_name
         self.service_type = service_type
 
     def get_bills(
         self,
-        date_from=datetime.now().strftime("01-01-%Y"),
-        date_to=datetime.now().strftime("%d-%m-%Y"),
+        date_from=datetime.now().strftime("01.01.%Y"),
+        date_to=datetime.now().strftime("%d.%m.%Y"),
     ):
-        url = "/".join((self.api_url, self.provider, "bills"))
-        headers = {"content-type": "application/json; charset=utf-8"}
-        data = {
-            "dateFrom": date_from,
-            "dateTo": date_to,
-            "accountNumber": self.account_id,
-            "serviceType": self.service_type,
-        }
-        response = self.session.post(url, data=json.dumps(data), headers=headers)
-        return response.json()
+        response = self.session.get(
+            self.api_url + "/v7/bills/payments",
+            params={
+                "provider": self.provider,
+                "account": self.account_id,
+                "from": date_from,
+                "to": date_to,
+            },
+        )
+
+        return [
+            self.session.get(self.api_url + "/v8/payments/bills/" + bill_id).json()
+            for bill_id in response.json()
+        ]
+    
+    def download_bill(self, bill_id, filename):
+        uuid = self.session.get(self.api_url + f"{self.account_id}/payments/bills/{bill_id}/uuid").json()
+
+        response = self.session.get(self.api_url + f"/v1/file/{uuid}", stream=True)
+        with open(filename, "wb") as file:
+            for chunk in response.iter_content(chunk_size=8192):
+                file.write(chunk)
 
     def get_payments(
         self,
-        date_from=datetime.now().strftime("01-01-%Y"),
-        date_to=datetime.now().strftime("%d-%m-%Y"),
+        date_from=datetime.now().strftime("01.01.%Y"),
+        date_to=datetime.now().strftime("%d.%m.%Y"),
     ):
-        url = "/".join((self.api_url, self.provider, "payments"))
-        headers = {"content-type": "application/json; charset=utf-8"}
-        data = {
-            "account": {"accountNumber": self.account_id},
-            "period": {"dateFrom": date_from, "dateTo": date_to},
-            "serviceType": self.service_type,
-        }
-        response = self.session.post(url, data=json.dumps(data), headers=headers)
-        return response.json()
+        response = self.session.get(
+            self.api_url + "/v7/payments",
+            params={
+                "provider": self.provider,
+                "account": self.account_id,
+                "from": date_from,
+                "to": date_to,
+            },
+        )
+
+        return [
+            self.session.get(self.api_url + "/v8/payments/" + payment_id).json()
+            for payment_id in response.json()
+        ]
 
     def get_meters(self):
         url = "/".join((self.api_url, self.provider, "meters"))
@@ -137,6 +159,9 @@ class PescAccount(PescObject):
             )
             for meter in response.json()
         ]
+
+    # get_address
+    # https://ikus.pesc.ru/api/v8/accounts/.../address
 
     @property
     def meters(self):
@@ -195,9 +220,7 @@ class PescClient(PescObject):
         self.password = None
         self.type = None
 
-    def auth(
-        self, login: str, password: str, type: AuthType = AuthType.EMAIL
-    ) -> dict[str, any]:
+    def auth(self, login, password, type=AuthType.EMAIL):
         """
         Authentication function.
 
@@ -227,9 +250,6 @@ class PescClient(PescObject):
                 "password": password,
                 "type": type.value,
             },
-            headers={
-                "Content-Type": "application/json",
-            },
         )
 
         if response.status_code == 200:
@@ -258,25 +278,25 @@ class PescClient(PescObject):
         Returns
         _______
         dict
-        {
-            'userId': int,
-            'name': {
-                'first': str,
-                'last': str,
-                'patronymic': optional[str]
-            },
-            'fields': List[dict],
-            'phone': str,
-            'email': str,
-            'isConfirmed': bool,
-            'isOnBoardingViewed': bool
-        }
-        or
-        {
-            'errors': [
-                {'code': 401, 'message': 'Неавторизованный доступ'}
-            ]
-        }
+            {
+                'userId': int,
+                'name': {
+                    'first': str,
+                    'last': str,
+                    'patronymic': optional[str]
+                },
+                'fields': List[dict],
+                'phone': str,
+                'email': str,
+                'isConfirmed': bool,
+                'isOnBoardingViewed': bool
+            }
+            or
+            {
+                'errors': [
+                    {'code': 401, 'message': 'Неавторизованный доступ'}
+                ]
+            }
         """
 
         response = self.session.get(self.api_url + "/v6/users/current")
@@ -293,16 +313,32 @@ class PescClient(PescObject):
         return response.json()
 
     def get_accounts(self):
-        url = self.api_url + "/accounts"
-        response = self.session.get(url)
+        """
+        Function for getting accounts.
+
+        Returns
+        _______
+        List[PescAccount]
+        """
+        response = self.session.get(self.api_url + "/v8/accounts")
+        if response.status_code != 200:
+            return {
+                "errors": [
+                    {
+                        "code": response.status_code,
+                        "message": response.json().get("message", "Unknown error"),
+                    }
+                ]
+            }
+
         return [
             PescAccount(
                 self.session,
-                account["accountNumber"],
-                account["providerName"],
-                account["serviceName"],
+                account["id"],
+                account["service"]["providerId"],
+                account["service"]["id"],
             )
-            for account in response.json()["ELECTRICITY"]
+            for account in response.json()
         ]
 
     @property

--- a/pesc/client.py
+++ b/pesc/client.py
@@ -5,10 +5,12 @@ pesc.client
 """
 
 import json
-from datetime import datetime
 import requests
 
-ROOT_URL = 'https://ikus.pesc.ru'
+from datetime import datetime
+from enum import Enum
+
+ROOT_URL = "https://ikus.pesc.ru"
 
 
 class PescObject:
@@ -16,6 +18,7 @@ class PescObject:
     This is base class.
 
     """
+
     def __init__(self, session=requests.Session()):
         self.session = session
 
@@ -25,51 +28,53 @@ class PescMeter(PescObject):
     This class for electric meter.
 
     """
-    def __init__(self, session, account_id, provider, service_type,
-                 meter_id, meter_number):
+
+    def __init__(
+        self, session, account_id, provider, service_type, meter_id, meter_number
+    ):
         super().__init__(session=session)
         self.account_id = account_id
         self.provider = provider
         self.service_type = service_type
-        self.api_url = ROOT_URL + '/application/accounts'
+        self.api_url = ROOT_URL + "/application/accounts"
         self.meter_id = meter_id
         self.meter_number = meter_number
 
     @property
     def info(self):
-        url = '/'.join((self.api_url, self.provider,
-                        'meters', str(self.meter_id)))
-        headers = {'content-type': 'application/json; charset=utf-8'}
+        url = "/".join((self.api_url, self.provider, "meters", str(self.meter_id)))
+        headers = {"content-type": "application/json; charset=utf-8"}
         response = self.session.get(url, headers=headers)
         return response.json()
 
-    def get_indications(self, date_from=datetime.now().strftime('01-01-%Y'),
-                        date_to=datetime.now().strftime('%d-%m-%Y')):
-        url = '/'.join((self.api_url, self.provider, 'indications'))
-        headers = {'content-type': 'application/json; charset=utf-8'}
-        data = {'meterId': self.meter_id,
-                'dateFrom': date_from,
-                'dateTo': date_to}
-        response = self.session.post(url, data=json.dumps(data),
-                                     headers=headers)
+    def get_indications(
+        self,
+        date_from=datetime.now().strftime("01-01-%Y"),
+        date_to=datetime.now().strftime("%d-%m-%Y"),
+    ):
+        url = "/".join((self.api_url, self.provider, "indications"))
+        headers = {"content-type": "application/json; charset=utf-8"}
+        data = {"meterId": self.meter_id, "dateFrom": date_from, "dateTo": date_to}
+        response = self.session.post(url, data=json.dumps(data), headers=headers)
         return response.json()
 
     def post_indication(self, day=0, night=0):
-        url = '/'.join((self.api_url, self.provider, 'indication/new'))
-        headers = {'content-type': 'application/json; charset=utf-8'}
-        data = {'account': {'accountNumber': self.account_id},
-                'serviceType': self.service_type,
-                'meterId': self.meter_id,
-                'indication': [{'scale': "DAY", 'value': day},
-                               {'scale': "NIGHT", 'value': night}]
-                }
-        response = self.session.post(url, data=json.dumps(data),
-                                     headers=headers)
+        url = "/".join((self.api_url, self.provider, "indication/new"))
+        headers = {"content-type": "application/json; charset=utf-8"}
+        data = {
+            "account": {"accountNumber": self.account_id},
+            "serviceType": self.service_type,
+            "meterId": self.meter_id,
+            "indication": [
+                {"scale": "DAY", "value": day},
+                {"scale": "NIGHT", "value": night},
+            ],
+        }
+        response = self.session.post(url, data=json.dumps(data), headers=headers)
         return response.json()
 
     def __repr__(self):
-        return 'Meter {} from account {}'.format(self.meter_number,
-                                                 self.account_id)
+        return "Meter {} from account {}".format(self.meter_number, self.account_id)
 
 
 class PescAccount(PescObject):
@@ -77,46 +82,61 @@ class PescAccount(PescObject):
     This is class for consumer account.
 
     """
+
     def __init__(self, session, account_id, provider_name, service_type):
         super().__init__(session=session)
-        self.api_url = ROOT_URL + '/application/accounts'
+        self.api_url = ROOT_URL + "/application/accounts"
         self.account_id = account_id
         self.provider = provider_name
         self.service_type = service_type
 
-    def get_bills(self, date_from=datetime.now().strftime('01-01-%Y'),
-                  date_to=datetime.now().strftime('%d-%m-%Y')):
-        url = '/'.join((self.api_url, self.provider, 'bills'))
-        headers = {'content-type': 'application/json; charset=utf-8'}
-        data = {'dateFrom': date_from, 'dateTo': date_to,
-                'accountNumber': self.account_id,
-                'serviceType': self.service_type}
-        response = self.session.post(url, data=json.dumps(data),
-                                     headers=headers)
+    def get_bills(
+        self,
+        date_from=datetime.now().strftime("01-01-%Y"),
+        date_to=datetime.now().strftime("%d-%m-%Y"),
+    ):
+        url = "/".join((self.api_url, self.provider, "bills"))
+        headers = {"content-type": "application/json; charset=utf-8"}
+        data = {
+            "dateFrom": date_from,
+            "dateTo": date_to,
+            "accountNumber": self.account_id,
+            "serviceType": self.service_type,
+        }
+        response = self.session.post(url, data=json.dumps(data), headers=headers)
         return response.json()
 
-    def get_payments(self, date_from=datetime.now().strftime('01-01-%Y'),
-                     date_to=datetime.now().strftime('%d-%m-%Y')):
-        url = '/'.join((self.api_url, self.provider, 'payments'))
-        headers = {'content-type': 'application/json; charset=utf-8'}
-        data = {'account': {'accountNumber': self.account_id},
-                'period': {'dateFrom': date_from, 'dateTo': date_to},
-                'serviceType': self.service_type}
-        response = self.session.post(url, data=json.dumps(data),
-                                     headers=headers)
+    def get_payments(
+        self,
+        date_from=datetime.now().strftime("01-01-%Y"),
+        date_to=datetime.now().strftime("%d-%m-%Y"),
+    ):
+        url = "/".join((self.api_url, self.provider, "payments"))
+        headers = {"content-type": "application/json; charset=utf-8"}
+        data = {
+            "account": {"accountNumber": self.account_id},
+            "period": {"dateFrom": date_from, "dateTo": date_to},
+            "serviceType": self.service_type,
+        }
+        response = self.session.post(url, data=json.dumps(data), headers=headers)
         return response.json()
 
     def get_meters(self):
-        url = '/'.join((self.api_url, self.provider, 'meters'))
-        headers = {'content-type': 'application/json; charset=utf-8'}
-        data = {'accountNumber': self.account_id,
-                'serviceType': self.service_type}
-        response = self.session.post(url, data=json.dumps(data),
-                                     headers=headers)
-        return [PescMeter(self.session, self.account_id,
-                          self.provider, self.service_type,
-                          meter['meterId'], meter['meterNumber'])
-                for meter in response.json()]
+        url = "/".join((self.api_url, self.provider, "meters"))
+        headers = {"content-type": "application/json; charset=utf-8"}
+        data = {"accountNumber": self.account_id, "serviceType": self.service_type}
+        response = self.session.post(url, data=json.dumps(data), headers=headers)
+        return [
+            PescMeter(
+                self.session,
+                self.account_id,
+                self.provider,
+                self.service_type,
+                meter["meterId"],
+                meter["meterNumber"],
+            )
+            for meter in response.json()
+        ]
 
     @property
     def meters(self):
@@ -124,46 +144,38 @@ class PescAccount(PescObject):
 
     @property
     def status(self):
-        url = '/'.join((self.api_url, self.provider, 'status'))
-        headers = {'content-type': 'application/json; charset=utf-8'}
-        data = {'accountNumber': self.account_id,
-                'serviceType': self.service_type}
-        response = self.session.post(url, data=json.dumps(data),
-                                     headers=headers)
+        url = "/".join((self.api_url, self.provider, "status"))
+        headers = {"content-type": "application/json; charset=utf-8"}
+        data = {"accountNumber": self.account_id, "serviceType": self.service_type}
+        response = self.session.post(url, data=json.dumps(data), headers=headers)
         return response.json()
 
     @property
     def debt(self):
-        url = '/'.join((self.api_url, self.provider, 'debt'))
-        headers = {'content-type': 'application/json; charset=utf-8'}
-        data = {'accountNumber': self.account_id,
-                'serviceType': self.service_type}
-        response = self.session.post(url, data=json.dumps(data),
-                                     headers=headers)
+        url = "/".join((self.api_url, self.provider, "debt"))
+        headers = {"content-type": "application/json; charset=utf-8"}
+        data = {"accountNumber": self.account_id, "serviceType": self.service_type}
+        response = self.session.post(url, data=json.dumps(data), headers=headers)
         return response.json()
 
     @property
     def active_payments(self):
-        url = '/'.join((self.api_url, self.provider, 'activePayments'))
-        headers = {'content-type': 'application/json; charset=utf-8'}
-        data = {'accountNumber': self.account_id,
-                'serviceType': self.service_type}
-        response = self.session.post(url, data=json.dumps(data),
-                                     headers=headers)
+        url = "/".join((self.api_url, self.provider, "activePayments"))
+        headers = {"content-type": "application/json; charset=utf-8"}
+        data = {"accountNumber": self.account_id, "serviceType": self.service_type}
+        response = self.session.post(url, data=json.dumps(data), headers=headers)
         return response.json()
 
     @property
     def address(self):
-        url = '/'.join((self.api_url, self.provider, 'address'))
-        headers = {'content-type': 'application/json; charset=utf-8'}
-        data = {'accountNumber': self.account_id,
-                'serviceType': self.service_type}
-        response = self.session.post(url, data=json.dumps(data),
-                                     headers=headers)
-        return response.json()['address']
+        url = "/".join((self.api_url, self.provider, "address"))
+        headers = {"content-type": "application/json; charset=utf-8"}
+        data = {"accountNumber": self.account_id, "serviceType": self.service_type}
+        response = self.session.post(url, data=json.dumps(data), headers=headers)
+        return response.json()["address"]
 
     def __repr__(self):
-        return 'Account {} at {}'.format(self.account_id, self.address)
+        return "Account {} at {}".format(self.account_id, self.address)
 
 
 class PescClient(PescObject):
@@ -171,36 +183,73 @@ class PescClient(PescObject):
     This is class for access data.
 
     """
+
+    class AuthType(Enum):
+        EMAIL = "EMAIL"
+        PHONE = "PHONE"
+
     def __init__(self, session_path=None):
         super().__init__()
-        self.api_url = ROOT_URL + '/application'
-        self.username = None
+        self.api_url = ROOT_URL + "/api"
+        self.login = None
         self.password = None
+        self.type = None
 
-    def auth(self, username, password):
+    def auth(
+        self, login: str, password: str, type: AuthType = AuthType.EMAIL
+    ) -> dict[str, any]:
         """
         Authentication function.
 
         Parameters
         __________
-        username: str
-            username
+        login: str
+            login
         password: str
             password
+        type: AuthType
+            type of authentication, default is AuthType.EMAIL
 
         Returns
         _______
         dict
             {'authenticationSuccess': True} or
-            {'errors': [{'code': 3, 'message': 'Неверный пароль'}]}
+            {'errors': [{'code': 5, 'message': 'Неавторизованный доступ'}]}
         """
-        self.username = username
+        self.login = login
         self.password = password
-        url = self.api_url + '/authentication'
-        data = {'username': username,
-                'password': password}
-        response = self.session.post(url, data=data)
-        return response.json()
+        self.type = type
+
+        response = self.session.post(
+            self.api_url + "/v8/users/auth",
+            json={
+                "login": login,
+                "password": password,
+                "type": type.value,
+            },
+            headers={
+                "Content-Type": "application/json",
+            },
+        )
+
+        if response.status_code == 200:
+            token = response.json().get("auth")
+            self.session.headers.update(
+                {
+                    "Authorization": f"Bearer {token}",
+                }
+            )
+
+            return {"authenticationSuccess": True}
+
+        return {
+            "errors": [
+                {
+                    "code": response.status_code,
+                    "message": response.json().get("message", "Unknown error"),
+                }
+            ]
+        }
 
     def check_auth(self):
         """
@@ -214,18 +263,22 @@ class PescClient(PescObject):
              'hasPersonalInfo': True} or
             {'errors': [{'code': 5, 'message': 'Неавторизованный доступ'}]}
         """
-        url = self.api_url + '/checkAuthentication'
-        response = self.session.get(url)
+
+        response = self.session.get(self.api_url + "/v6/users/current")
         return response.json()
 
     def get_accounts(self):
-        url = self.api_url + '/accounts'
+        url = self.api_url + "/accounts"
         response = self.session.get(url)
-        return [PescAccount(self.session,
-                            account['accountNumber'],
-                            account['providerName'],
-                            account['serviceName'])
-                for account in response.json()['ELECTRICITY']]
+        return [
+            PescAccount(
+                self.session,
+                account["accountNumber"],
+                account["providerName"],
+                account["serviceName"],
+            )
+            for account in response.json()["ELECTRICITY"]
+        ]
 
     @property
     def accounts(self):
@@ -233,7 +286,7 @@ class PescClient(PescObject):
 
     @property
     def notifications(self):
-        url = self.api_url + '/notifications'
+        url = self.api_url + "/notifications"
         response = self.session.get(url)
         try:
             notifications = response.json()
@@ -250,6 +303,6 @@ class PescClient(PescObject):
         dict
             {'logoutSuccess': True}
         """
-        url = self.api_url + '/logout'
+        url = self.api_url + "/logout"
         response = self.session.get(url)
         return response.json()

--- a/pesc/client.py
+++ b/pesc/client.py
@@ -162,26 +162,10 @@ class PescAccount(PescObject):
         return self.get_meters()
 
     @property
-    def status(self):
-        url = "/".join((self.api_url, self.provider, "status"))
-        headers = {"content-type": "application/json; charset=utf-8"}
-        data = {"accountNumber": self.account_id, "serviceType": self.service_type}
-        response = self.session.post(url, data=json.dumps(data), headers=headers)
-        return response.json()
-
-    @property
     def debt(self):
         return self.session.get(
             f"{self.api_url}/v8/accounts/{self.account_id}/payments/bills/current"
         ).json()
-
-    @property
-    def active_payments(self):
-        url = "/".join((self.api_url, self.provider, "activePayments"))
-        headers = {"content-type": "application/json; charset=utf-8"}
-        data = {"accountNumber": self.account_id, "serviceType": self.service_type}
-        response = self.session.post(url, data=json.dumps(data), headers=headers)
-        return response.json()
 
     @property
     def address(self):
@@ -336,13 +320,18 @@ class PescClient(PescObject):
 
     @property
     def notifications(self):
-        url = self.api_url + "/notifications"
-        response = self.session.get(url)
-        try:
-            notifications = response.json()
-        except json.decoder.JSONDecodeError:
-            notifications = response.text
-        return notifications
+        types = ["top", "bell", "onboarding", "modal"]
+
+        return {
+            type: self.session.get(
+                f"{self.api_url}/v6/notifications",
+                params={
+                    "type": type,
+                    "state": "unread",
+                },
+            ).json()
+            for type in types
+        }
 
     def logout(self):
         """

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Pesc-api
 
 Simple python module which provide access to data from [ikus.pesc.ru](https://ikus.pesc.ru/).
-Before you use the wrapper you need to register on the [site](https://ikus.pesc.ru/login).
+Before you use the wrapper you need to register on the [site](https://ikus.pesc.ru/auth/login).
 
 ## Authentication
 
@@ -9,6 +9,15 @@ Before you use the wrapper you need to register on the [site](https://ikus.pesc.
 >>> from pesc import PescClient
 >>> client = PescClient()
 >>> client.auth('sa@prg.re', 'password')
+{'authenticationSuccess': True}
+```
+
+Also it is possible to authenticate with a phone number.
+
+```python
+>>> from pesc import PescClient
+>>> client = PescClient()
+>>> client.auth('+79001002030', 'password', PescClient.AuthType.PHONE)
 {'authenticationSuccess': True}
 ```
 
@@ -22,26 +31,32 @@ Before you use the wrapper you need to register on the [site](https://ikus.pesc.
 ### Bills
 
 ```python
->>> bills = account.get_bills(date_from='30-12-2010', date_to='01-01-2016')
+>>> bills = account.get_bills(date_from='30.12.2010', date_to='01.01.2016')
 >>> bills[0]
-{'billId': 130098827, 'period': '01-01-2016', 'billNumber': 52, 'sum': 0.31}
+{'id': '000000000000000', 'externalId': None, 'accountId': 00000000, 'amount': 0.31, 'timestamp': '01.04.2016 00:00:00', 'file': None, 'canDownload': True}
+```
+
+It is possible to download bill file.
+
+```python
+>>> account.download_bill(bills[0]["id"], f'bill.pdf')
 ```
 
 ### Payments
 
 ```python
->>> payments = accounts[0].get_payments(date_from='01-01-2018', date_to='30-05-2018')
+>>> payments = account.get_payments(date_from='01.01.2018', date_to='30.05.2018')
 >>> payments[0]
-{'date': '09-01-2018', 'sum': 1020.74, 'type': 'Счет', 'charge': 1020.74, 'fine': 0.0, 'period': '01-01-2018', 'checkExists': True, 'status': 'DONE'}
+{'accountId': 00000000, 'status': 'SUCCESS', 'details': [{'subserviceId': 00000, 'providerServiceId': 000, 'providerServiceName': 'НО "ФКР МКД СПб"', 'fine': {'balance': None, 'accrued': 0.0}, 'charge': {'balance': None, 'accrued': 0000.00}, 'checked': True}], 'timestamp': '2026-04-06T12:00', 'id': '0000000000000', 'file': None, 'receiptUrl': None}
 ```
 
 ## Meters
 
 ```python
->>> meters = accounts[0].meters
+>>> meters = account.meters
 >>> meter = meters[0]
 >>> meter.info
-{'meterId': 4512623, 'meterNumber': '031296508', 'meterModel': 'ЦЭ2726-12', 'installationDate': '06-06-2011', 'installationPlace': 'КВАРТИРА', 'owner': 'Абонент', 'precision': '1,0', 'voltage': '220', 'current': '5-60', 'calibrationInterval': None, 'tarifficationPlan': 'Двухтарифный', 'relationType': {'relationTypeText': 'Индивидуальный', 'relationTypeCode': 'INDIVIDUAL'}, 'meterState': {'meterStateText': 'Исправный', 'meterStateCode': 'WORKING'}, 'meterType': {'meterTypeText': 'Обычный ПУ', 'meterTypeCode': 'REGULAR'}, 'accountStatus': None, 'numberOfDigitsInScale': 6, 'numberOfScales': 2, 'scales': ['DAY', 'NIGHT']}
+[{'id': {'provider': 1100, 'registration': '0000000000'}, 'name': 'Электроэнергия', 'numberOfDigitsLeft': 6, 'numberOfDigitsRight': 0, 'serial': '000000', 'status': 'ACTIVE', 'indications': [{'previousReadingDate': '01.05.2026', 'meterScaleId': 2, 'indicationId': None, 'scaleName': 'День', 'previousReading': 0000.0, 'registerReading': None, 'unit': 'кВт*ч'}, {'previousReadingDate': '01.05.2016', 'meterScaleId': 3, 'indicationId': None, 'scaleName': 'Ночь', 'previousReading': 0000.0, 'registerReading': None, 'unit': 'кВт*ч'}], 'subserviceId': 00000}]
 ```
 
 ### Indications
@@ -49,13 +64,21 @@ Before you use the wrapper you need to register on the [site](https://ikus.pesc.
 Get indications
 
 ```python
->>> indications = meter.get_indications(date_from='01-01-2018', date_to='30-05-2018')
+>>> indications = meter.get_indications(date_from='01.01.2018', date_to='30.05.2018')
 >>> indications[0]
-{'type': 'Заявленные показания', 'date': '22-09-2018', 'scaleValues': [{'scale': 'DAY', 'value': 14867}, {'scale': 'NIGHT', 'value': 7092}]}
+{'key': '01.05.2016', 'value': [{'key': 00000000, 'value': [{'meterId': {'provider': 1100, 'registration': '00000000000'}, 'period': {'name': '01.05.2016', 'interval': {'dateFrom': '01.05.2016', 'dateTo': '01.05.2016'}, 'deadLine': None}, 'values': [{'scale': 'День', 'value': 0000.0, 'unit': 'кВт*ч', 'consumption': None}, {'scale': 'Ночь', 'value': 0000.0, 'unit': 'кВт*ч', 'consumption': None}], 'source': None}]}]}
 ```
 
 Post indication
 
 ```python
 >>> meter.post_indication(day=105, night=10)
+True
+```
+
+### Logout
+
+```python
+>>> client.logout()
+{'logoutSuccess': True}
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ certifi==2018.4.16
 chardet==3.0.4
 coverage==4.5.1
 idna==2.7
+PyJWT==2.10.1
 requests==2.21.0
 urllib3==1.23


### PR DESCRIPTION
Hi! For this 7 years ikus.pesc.ru have been really changed. And upstream API wrapper is outdated.

What's changed:
- This pull requests apply new API schema for existing methods.
- Adds `download_bill` method to get bill as a file with QR bar from the site.

## Summary by Sourcery

Migrate API wrapper to the new ikus.pesc.ru schema (v6–v8), updating all client, account, and meter methods to modern endpoints and payloads, add support for JWT-based authentication (including phone login), implement bill file download and logout functionality.

New Features:
- Add download_bill method to fetch and save billing PDFs
- Introduce AuthType enum to support email and phone authentication
- Implement logout method that invalidates JWT sessions

Enhancements:
- Rewrite all API calls (meters, accounts, indications, bills, payments, debt, address) to v6–v8 endpoints with JSON parameters and responses
- Centralize session headers for JSON content-type and manage Authorization header via JWT tokens in auth

Build:
- Add PyJWT dependency for JWT handling

Documentation:
- Update readme with new auth endpoint, phone login example, date formatting changes, download_bill and logout usage